### PR TITLE
devop: improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@
 FROM golang:1.19-bullseye AS builder
 
 WORKDIR /app
-COPY . .
 
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
 RUN ENABLE_CGO=0 go build -o interfacer-proxy .
+
 
 FROM dyne/devuan:chimaera AS worker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ENABLE_CGO=0 go build -o interfacer-proxy .
 FROM dyne/devuan:chimaera AS worker
 
 ARG PORT=8080
-ENV PORT=$PORT
+ENV ADDR=:$PORT
 ARG USER=app
 ENV USER=$USER
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM golang:1.19-bullseye AS builder
+ARG GOVER=1.18
+FROM golang:$GOVER-bullseye AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ FROM dyne/devuan:chimaera AS worker
 ARG PORT=8080
 ENV ADDR=:$PORT
 ARG USER=app
-ENV USER=$USER
 
 ENV IFACER_LOG="/log"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN ENABLE_CGO=0 go build -o interfacer-proxy .
 
 
-FROM dyne/devuan:chimaera AS worker
+FROM dyne/devuan:chimaera
 
 ARG PORT=8080
 ENV ADDR=:$PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM golang:1.19-bullseye AS builder
 
 WORKDIR /app
-ADD . .
+COPY . .
 
 RUN ENABLE_CGO=0 go build -o interfacer-proxy .
 


### PR DESCRIPTION
* ARG-ify the Go version, and fix the version number.
* Fix the name of the environment variable that is used for listening.
* Cache the downloaded Go modules.