### PR TITLE
devop: use GONOPROXY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 
 ARG GOVER=1.18
 FROM golang:$GOVER-bullseye AS builder
+ENV GONOPROXY=
 
 WORKDIR /app
 


### PR DESCRIPTION
Because Google is evil.