### PR TITLE
Fix(log): Change INTERFACER_LOG to be a file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,14 +33,14 @@ ARG PORT=8080
 ENV ADDR=:$PORT
 ARG USER=app
 
-ENV IFACER_LOG="/log"
+ENV IFACER_LOG="/app/proxy.log"
 
-RUN addgroup --system "$USER" && adduser --system --ingroup "$USER" "$USER" && \
-      install -d -m 0755 -o "$USER" -g "$USER" /log
+RUN addgroup --system "$USER" && adduser --system --ingroup "$USER" "$USER"
 
 WORKDIR /app
 
 COPY --from=builder /app/interfacer-proxy .
+RUN chown app:app /app/interfacer-proxy
 
 USER $USER
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ It can be started writing the `hosts.yaml` and running `make install` inside the
 In the `hosts.yaml` one has to provide:
  - `domain_name`: the FQDN of the server
  - `zenflows`: URL for the zenflows instanc3
- - `ifacer_log`: directory in which we want to save the logs
+ - `ifacer_log`: path to the log file
  - `port`: port for proxy on `localhost`
  - `here_api`: URL for the API of here.com
  - `inbox_port`: port for inbox on `localhost`

--- a/devops/roles/common/tasks/logs.yml
+++ b/devops/roles/common/tasks/logs.yml
@@ -17,7 +17,7 @@
 ---
 - name: Create a directory if it does not exist
   ansible.builtin.file:
-    path: "{{ ifacer_log }}"
+    path: "{{ ifacer_log | dirname }}"
     state: directory
     mode: '0755'
     owner: root
@@ -32,7 +32,7 @@
     dest: "/{{ basedir }}/.env.{{ port }}"
     create: true
     block: |
-      {{ ifacer_log }}* {
+      {{ ifacer_log }} {
         size 100M
         rotate 3
         compress

--- a/devops/roles/proxy-docker-compose/templates/docker-compose.yml.j2
+++ b/devops/roles/proxy-docker-compose/templates/docker-compose.yml.j2
@@ -29,7 +29,9 @@ services:
       WALLET_URL: "http://wallet"
       INTERFACER_DPP_URL: "http://interfacer-dpp:8080"
       OSH_URL: "http://osh/"
-      IFACER_LOG: "/log"
+      IFACER_LOG: "/app/proxy.log"
+    volumes:
+      - "{{ ifacer_log | dirname }}:/app"
     extra_hosts:
       - "gateway0.interfacer.dyne.org:10.202.41.10"
   inbox:

--- a/logger/log.go
+++ b/logger/log.go
@@ -17,19 +17,24 @@
 package logger
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
-	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 )
 
 var Log = logrus.New()
 
-func InitLog(logPath string) {
+func InitLog(logFile string) {
 	Log.SetFormatter(&logrus.JSONFormatter{})
 
 	Log.Out = os.Stdout
 
-	file, err := os.OpenFile(filepath.Join(logPath, "proxy.log"),
+	if logFile == "" {
+		Log.Info("Failed to log to file, using default stderr")
+		return
+	}
+
+	file, err := os.OpenFile(logFile,
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		Log.WithFields(logrus.Fields{"err": err.Error()}).

--- a/main.go
+++ b/main.go
@@ -20,15 +20,17 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/interfacerproject/interfacer-gateway/config"
-	"github.com/interfacerproject/interfacer-gateway/logger"
-	"github.com/sirupsen/logrus"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
+
+	"github.com/interfacerproject/interfacer-gateway/config"
+	"github.com/interfacerproject/interfacer-gateway/logger"
+	"github.com/sirupsen/logrus"
 )
 
 var conf *config.Config
@@ -233,7 +235,12 @@ func (p *ProxiedHost) addHandle() (string, func(w http.ResponseWriter, r *http.R
 }
 
 func main() {
-	logger.InitLog(os.Getenv("IFACER_LOG"))
+	logFile, ok := os.LookupEnv("IFACER_LOG")
+	if !ok {
+		log.Printf(`"IFACER_LOG" was not provided; defaulting to "proxy.log"`)
+		logFile = "proxy.log"
+	}
+	logger.InitLog(logFile)
 
 	var err error
 	conf, err = config.NewEnv()


### PR DESCRIPTION
This PR fixes issue #10 by changing the INTERFACER_LOG environment variable to be a path to a file instead of a directory. This makes the logging configuration more intuitive and aligns with common practices.